### PR TITLE
Fix null comparison error

### DIFF
--- a/lib/validators.dart
+++ b/lib/validators.dart
@@ -4,7 +4,7 @@ const DEFAULT_THUMB_QUALITY = 50;
 const DEFAULT_IMAGE_TYPE = ThumbFormat.JPEG;
 
 int validateQuality(int choice) {
-  if (choice < 10 || choice > 100 || choice == null)
+  if (choice == null || choice < 10 || choice > 100)
     return DEFAULT_THUMB_QUALITY;
   return choice;
 }


### PR DESCRIPTION
The program would crash if null was passed to validateQuality because the null check was being done last. The comparison "null < 10" was done which resulted in the crash. Fixed by doing the null check first.